### PR TITLE
Fixing encoding issue with image URLs

### DIFF
--- a/src/main/resources/static/js/dictionary.js
+++ b/src/main/resources/static/js/dictionary.js
@@ -91,8 +91,12 @@ $(document).ready(function () {
         var rowCount = table.rows.length;
         var row = table.insertRow(rowCount);
 
-        shuMin = numberWithCommas(shuMin);
-        shuMax = numberWithCommas(shuMax);
+        if(shuMin != null) {
+            shuMin = numberWithCommas(shuMin);
+        }
+        if(shuMax != null) {
+            shuMax = numberWithCommas(shuMax);
+        }
 
         if (shuMin == "") {
             shuMin = "unknown";


### PR DESCRIPTION
- Images had either broken or no UTF encoding on special characters
- Proper encoding was added, as well as a null check for any of the
  scoville values being changed to American notation (commas instead of
  periods) since otherwise it would cause errors